### PR TITLE
Storage

### DIFF
--- a/storage/array.go
+++ b/storage/array.go
@@ -1,0 +1,89 @@
+package storage
+
+import "slices"
+
+type ArrayQuery[T Primitive] struct {
+	DB  *DB
+	key string
+}
+
+func (aq *ArrayQuery[T]) Slice(left int, right int) ([]T, error) {
+	var nothing []T
+	array, err := aq.getArray()
+	if err != nil {
+		return nothing, err
+	}
+
+	if left >= len(array) {
+		return nothing, ErrOutOfRange
+	}
+	if right > len(array) {
+		return nothing, ErrOutOfRange
+	}
+
+	return array[left:right], nil
+}
+
+func (aq *ArrayQuery[T]) Insert(index int, elems ...T) error {
+	array, err := aq.getArray()
+	if err != nil {
+		return err
+	}
+
+	if index < 0 && index >= len(array) {
+		return ErrOutOfRange
+	}
+
+	for _, elem := range elems {
+		array[index] = elem
+		index++
+	}
+
+	aq.DB.syncMap.Store(aq.key, array)
+	return nil
+}
+
+func (aq *ArrayQuery[T]) Remove(left int, right int) ([]T, error) {
+	var nothing []T
+	array, err := aq.getArray()
+	if err != nil {
+		return nothing, err
+	}
+
+	if left < 0 || left >= len(array) {
+		return nothing, ErrOutOfRange
+	}
+	if right < 0 || right > len(array) {
+		return nothing, ErrOutOfRange
+	}
+
+	removed := slices.Delete(array, left, right)
+	aq.DB.syncMap.Store(aq.key, removed)
+	return removed, nil
+}
+
+func (aq *ArrayQuery[T]) Len() (int, error) {
+	array, err := aq.getArray()
+	if err != nil {
+		return 0, err
+	}
+	return len(array), err
+}
+
+func (aq *ArrayQuery[T]) Clear() {
+	aq.DB.syncMap.Store(aq.key, nil)
+}
+
+func (aq *ArrayQuery[T]) getArray() ([]T, error) {
+	var nothing []T
+	value, ok := aq.DB.syncMap.Load(aq.key)
+	if !ok {
+		return nothing, ErrNotFound
+	}
+
+	array, ok := value.([]T)
+	if !ok {
+		return nothing, ErrWrongType
+	}
+	return array, nil
+}

--- a/storage/array.go
+++ b/storage/array.go
@@ -29,6 +29,9 @@ func (aq *ArrayQuery[T]) Insert(index int, elems ...T) error {
 	if err != nil {
 		return err
 	}
+	if array == nil {
+		array = make([]T, 0)
+	}
 
 	if index < 0 && index >= len(array) {
 		return ErrOutOfRange

--- a/storage/array.go
+++ b/storage/array.go
@@ -27,10 +27,11 @@ func (aq *ArrayQuery[T]) Slice(left int, right int) ([]T, error) {
 func (aq *ArrayQuery[T]) Insert(index int, elems ...T) error {
 	array, err := aq.getArray()
 	if err != nil {
-		return err
-	}
-	if array == nil {
-		array = make([]T, 0)
+		if err == ErrNotFound {
+			array = make([]T, 0)
+		} else {
+			return err
+		}
 	}
 
 	if index < 0 && index >= len(array) {
@@ -74,7 +75,7 @@ func (aq *ArrayQuery[T]) Len() (int, error) {
 }
 
 func (aq *ArrayQuery[T]) Clear() {
-	aq.DB.syncMap.Store(aq.key, nil)
+	aq.DB.syncMap.Delete(aq.key)
 }
 
 func (aq *ArrayQuery[T]) getArray() ([]T, error) {

--- a/storage/array_test.go
+++ b/storage/array_test.go
@@ -1,0 +1,90 @@
+package storage
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestInsertAndSlice(t *testing.T) {
+	db := DB{}
+	k, v := "k", "v"
+	s := []string{v, v, v}
+	if err := db.ArrayString(k).Insert(0, s...); err != nil {
+		t.Fatalf("could not insert value: %v", err)
+	}
+
+	got, err := db.ArrayString(k).Slice(0, 3)
+	if err != nil {
+		t.Fatalf("could not get slice: %v", err)
+	}
+
+	if !slices.Equal(got, s) {
+		t.Errorf("got %v, expected %v", got, s)
+	}
+
+	if err := db.ArrayString(k).Insert(-1, s...); err == nil {
+		t.Fatalf("expected error: %v", ErrOutOfRange)
+	}
+
+	if _, err := db.ArrayString(k).Slice(-1, -1); err == nil {
+		t.Fatalf("expected error: %v", ErrOutOfRange)
+	}
+}
+
+func TestArrayRemove(t *testing.T) {
+	db := DB{}
+	k, v := "k", "v"
+	s := []string{v, v, v}
+	if err := db.ArrayString(k).Insert(0, s...); err != nil {
+		t.Fatalf("could not insert value: %v", err)
+	}
+
+	got, err := db.ArrayString(k).Remove(0, 3)
+	if err != nil {
+		t.Errorf("could not remove value: %v", err)
+	}
+
+	if !slices.Equal(got, s) {
+		t.Errorf("got %v, expected %v", got, s)
+	}
+
+	if _, err := db.ArrayString(k).Slice(0, 3); err == nil {
+		t.Fatalf("expected error: %v", ErrOutOfRange)
+	}
+
+	if _, err := db.ArrayString(k).Remove(-1, -1); err == nil {
+		t.Fatalf("expected error: %v", ErrOutOfRange)
+	}
+}
+
+func TestArrayLen(t *testing.T) {
+	db := DB{}
+	k, v := "k", "v"
+	s := []string{v, v, v}
+	if err := db.ArrayString(k).Insert(0, s...); err != nil {
+		t.Fatalf("could not insert value: %v", err)
+	}
+
+	l, err := db.ArrayString(k).Len()
+	if err != nil {
+		t.Fatalf("could not get length: %v", err)
+	}
+
+	expected := len(s)
+	if l != expected {
+		t.Errorf("got length %d, expected %d", l, expected)
+	}
+}
+
+func TestClear(t *testing.T) {
+	db := DB{}
+	k, v := "k", "v"
+	s := []string{v, v, v}
+	if err := db.ArrayString(k).Insert(0, s...); err != nil {
+		t.Fatalf("could not insert value: %v", err)
+	}
+	db.ArrayString(k).Clear()
+	if _, err := db.ArrayString(k).Len(); err == nil {
+		t.Errorf("expected error: %v", ErrNotFound)
+	}
+}

--- a/storage/db.go
+++ b/storage/db.go
@@ -8,112 +8,112 @@ type DB struct {
 	syncMap sync.Map
 }
 
-func (db *DB) String(key string) PrimitiveQuery[string] {
-	pq := PrimitiveQuery[string]{
+func (db *DB) String(key string) *PrimitiveQuery[string] {
+	pq := &PrimitiveQuery[string]{
 		DB:  db,
 		key: key,
 	}
 	return pq
 }
 
-func (db *DB) Int(key string) PrimitiveQuery[int64] {
-	pq := PrimitiveQuery[int64]{
+func (db *DB) Int(key string) *PrimitiveQuery[int64] {
+	pq := &PrimitiveQuery[int64]{
 		DB:  db,
 		key: key,
 	}
 	return pq
 }
 
-func (db *DB) Float(key string) PrimitiveQuery[float64] {
-	pq := PrimitiveQuery[float64]{
+func (db *DB) Float(key string) *PrimitiveQuery[float64] {
+	pq := &PrimitiveQuery[float64]{
 		DB:  db,
 		key: key,
 	}
 	return pq
 }
 
-func (db *DB) Bool(key string) PrimitiveQuery[bool] {
-	pq := PrimitiveQuery[bool]{
+func (db *DB) Bool(key string) *PrimitiveQuery[bool] {
+	pq := &PrimitiveQuery[bool]{
 		DB:  db,
 		key: key,
 	}
 	return pq
 }
 
-func (db *DB) Blob(key string) PrimitiveQuery[[]byte] {
-	pq := PrimitiveQuery[[]byte]{
+func (db *DB) Blob(key string) *PrimitiveQuery[[]byte] {
+	pq := &PrimitiveQuery[[]byte]{
 		DB:  db,
 		key: key,
 	}
 	return pq
 }
 
-func (db *DB) ArrayString(key string) ArrayQuery[string] {
-	aq := ArrayQuery[string]{
+func (db *DB) ArrayString(key string) *ArrayQuery[string] {
+	aq := &ArrayQuery[string]{
 		DB:  db,
 		key: key,
 	}
 	return aq
 }
 
-func (db *DB) ArrayInt(key string) ArrayQuery[int64] {
-	aq := ArrayQuery[int64]{
+func (db *DB) ArrayInt(key string) *ArrayQuery[int64] {
+	aq := &ArrayQuery[int64]{
 		DB:  db,
 		key: key,
 	}
 	return aq
 }
 
-func (db *DB) ArrayFloat(key string) ArrayQuery[float64] {
-	aq := ArrayQuery[float64]{
+func (db *DB) ArrayFloat(key string) *ArrayQuery[float64] {
+	aq := &ArrayQuery[float64]{
 		DB:  db,
 		key: key,
 	}
 	return aq
 }
 
-func (db *DB) ArrayBlob(key string) ArrayQuery[[]byte] {
-	aq := ArrayQuery[[]byte]{
+func (db *DB) ArrayBlob(key string) *ArrayQuery[[]byte] {
+	aq := &ArrayQuery[[]byte]{
 		DB:  db,
 		key: key,
 	}
 	return aq
 }
 
-func (db *DB) MapString(key string) MapQuery[string] {
-	mq := MapQuery[string]{
+func (db *DB) MapString(key string) *MapQuery[string] {
+	mq := &MapQuery[string]{
 		DB:  db,
 		key: key,
 	}
 	return mq
 }
 
-func (db *DB) MapInt(key string) MapQuery[int64] {
-	mq := MapQuery[int64]{
+func (db *DB) MapInt(key string) *MapQuery[int64] {
+	mq := &MapQuery[int64]{
 		DB:  db,
 		key: key,
 	}
 	return mq
 }
 
-func (db *DB) MapFloat(key string) MapQuery[float64] {
-	mq := MapQuery[float64]{
+func (db *DB) MapFloat(key string) *MapQuery[float64] {
+	mq := &MapQuery[float64]{
 		DB:  db,
 		key: key,
 	}
 	return mq
 }
 
-func (db *DB) MapBool(key string) MapQuery[bool] {
-	mq := MapQuery[bool]{
+func (db *DB) MapBool(key string) *MapQuery[bool] {
+	mq := &MapQuery[bool]{
 		DB:  db,
 		key: key,
 	}
 	return mq
 }
 
-func (db *DB) MapBlob(key string) MapQuery[[]byte] {
-	mq := MapQuery[[]byte]{
+func (db *DB) MapBlob(key string) *MapQuery[[]byte] {
+	mq := &MapQuery[[]byte]{
 		DB:  db,
 		key: key,
 	}

--- a/storage/db.go
+++ b/storage/db.go
@@ -1,0 +1,121 @@
+package storage
+
+import (
+	"sync"
+)
+
+type DB struct {
+	syncMap sync.Map
+}
+
+func (db *DB) String(key string) PrimitiveQuery[string] {
+	pq := PrimitiveQuery[string]{
+		DB:  db,
+		key: key,
+	}
+	return pq
+}
+
+func (db *DB) Int(key string) PrimitiveQuery[int64] {
+	pq := PrimitiveQuery[int64]{
+		DB:  db,
+		key: key,
+	}
+	return pq
+}
+
+func (db *DB) Float(key string) PrimitiveQuery[float64] {
+	pq := PrimitiveQuery[float64]{
+		DB:  db,
+		key: key,
+	}
+	return pq
+}
+
+func (db *DB) Bool(key string) PrimitiveQuery[bool] {
+	pq := PrimitiveQuery[bool]{
+		DB:  db,
+		key: key,
+	}
+	return pq
+}
+
+func (db *DB) Blob(key string) PrimitiveQuery[[]byte] {
+	pq := PrimitiveQuery[[]byte]{
+		DB:  db,
+		key: key,
+	}
+	return pq
+}
+
+func (db *DB) ArrayString(key string) ArrayQuery[string] {
+	aq := ArrayQuery[string]{
+		DB:  db,
+		key: key,
+	}
+	return aq
+}
+
+func (db *DB) ArrayInt(key string) ArrayQuery[int64] {
+	aq := ArrayQuery[int64]{
+		DB:  db,
+		key: key,
+	}
+	return aq
+}
+
+func (db *DB) ArrayFloat(key string) ArrayQuery[float64] {
+	aq := ArrayQuery[float64]{
+		DB:  db,
+		key: key,
+	}
+	return aq
+}
+
+func (db *DB) ArrayBlob(key string) ArrayQuery[[]byte] {
+	aq := ArrayQuery[[]byte]{
+		DB:  db,
+		key: key,
+	}
+	return aq
+}
+
+func (db *DB) MapString(key string) MapQuery[string] {
+	mq := MapQuery[string]{
+		DB:  db,
+		key: key,
+	}
+	return mq
+}
+
+func (db *DB) MapInt(key string) MapQuery[int64] {
+	mq := MapQuery[int64]{
+		DB:  db,
+		key: key,
+	}
+	return mq
+}
+
+func (db *DB) MapFloat(key string) MapQuery[float64] {
+	mq := MapQuery[float64]{
+		DB:  db,
+		key: key,
+	}
+	return mq
+}
+
+func (db *DB) MapBool(key string) MapQuery[bool] {
+	mq := MapQuery[bool]{
+		DB:  db,
+		key: key,
+	}
+	return mq
+}
+
+func (db *DB) MapBlob(key string) MapQuery[[]byte] {
+	mq := MapQuery[[]byte]{
+		DB:  db,
+		key: key,
+	}
+	return mq
+}

--- a/storage/db.go
+++ b/storage/db.go
@@ -72,6 +72,14 @@ func (db *DB) ArrayFloat(key string) *ArrayQuery[float64] {
 	return aq
 }
 
+func (db *DB) ArrayBool(key string) *ArrayQuery[bool] {
+	aq := &ArrayQuery[bool]{
+		DB:  db,
+		key: key,
+	}
+	return aq
+}
+
 func (db *DB) ArrayBlob(key string) *ArrayQuery[[]byte] {
 	aq := &ArrayQuery[[]byte]{
 		DB:  db,

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -1,0 +1,9 @@
+package storage
+
+import "fmt"
+
+var (
+	ErrWrongType  = fmt.Errorf("value of wrong type")
+	ErrNotFound   = fmt.Errorf("value not found")
+	ErrOutOfRange = fmt.Errorf("index out of range")
+)

--- a/storage/map.go
+++ b/storage/map.go
@@ -22,14 +22,16 @@ func (mq *MapQuery[T]) Get(key string) (T, error) {
 func (mq *MapQuery[T]) Set(key string, value T) error {
 	m, err := mq.getMap()
 	if err != nil {
-		return err
-	}
-	if m == nil {
-		m = make(map[string]T)
+		if err == ErrNotFound {
+			m = make(map[string]T)
+			mq.DB.syncMap.Store(mq.key, m)
+		} else {
+			return err
+		}
 	}
 
 	m[key] = value
-	return err
+	return nil
 }
 
 func (mq *MapQuery[T]) Remove(key string) (T, error) {

--- a/storage/map.go
+++ b/storage/map.go
@@ -24,6 +24,9 @@ func (mq *MapQuery[T]) Set(key string, value T) error {
 	if err != nil {
 		return err
 	}
+	if m == nil {
+		m = make(map[string]T)
+	}
 
 	m[key] = value
 	return err

--- a/storage/map.go
+++ b/storage/map.go
@@ -1,0 +1,112 @@
+package storage
+
+type MapQuery[T Primitive] struct {
+	DB  *DB
+	key string
+}
+
+func (mq *MapQuery[T]) Get(key string) (T, error) {
+	var nothing T
+	m, err := mq.getMap()
+	if err != nil {
+		return nothing, err
+	}
+
+	value, ok := m[key]
+	if !ok {
+		return nothing, ErrNotFound
+	}
+	return value, nil
+}
+
+func (mq *MapQuery[T]) Set(key string, value T) error {
+	m, err := mq.getMap()
+	if err != nil {
+		return err
+	}
+
+	m[key] = value
+	return err
+}
+
+func (mq *MapQuery[T]) Remove(key string) (T, error) {
+	var nothing T
+	m, err := mq.getMap()
+	if err != nil {
+		return nothing, err
+	}
+
+	value, ok := m[key]
+	if !ok {
+		return nothing, ErrNotFound
+	}
+	delete(m, key)
+	return value, nil
+}
+
+func (mq *MapQuery[T]) Contains(key string) (bool, error) {
+	m, err := mq.getMap()
+	if err != nil {
+		return false, err
+	}
+
+	_, ok := m[key]
+	if !ok {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (mq *MapQuery[T]) Len() (int, error) {
+	m, err := mq.getMap()
+	if err != nil {
+		return 0, err
+	}
+	return len(m), err
+}
+
+func (mq *MapQuery[T]) Keys() ([]string, error) {
+	var nothing []string
+	m, err := mq.getMap()
+	if err != nil {
+		return nothing, err
+	}
+
+	keys := make([]string, len(m))
+	var i int
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	return keys, err
+}
+
+func (mq *MapQuery[T]) Values() ([]T, error) {
+	var nothing []T
+	m, err := mq.getMap()
+	if err != nil {
+		return nothing, err
+	}
+
+	values := make([]T, len(m))
+	var i int
+	for _, v := range m {
+		values[i] = v
+		i++
+	}
+	return values, err
+}
+
+func (mq *MapQuery[T]) getMap() (map[string]T, error) {
+	var nothing map[string]T
+	value, ok := mq.DB.syncMap.Load(mq.key)
+	if !ok {
+		return nothing, ErrNotFound
+	}
+
+	m, ok := value.(map[string]T)
+	if !ok {
+		return nothing, ErrWrongType
+	}
+	return m, nil
+}

--- a/storage/map_test.go
+++ b/storage/map_test.go
@@ -95,7 +95,7 @@ func TestKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get keys: %v", err)
 	}
-	if slices.Equal(keys, got) {
+	if !slices.Equal(keys, got) {
 		t.Errorf("got %v, expected %v", got, keys)
 	}
 }
@@ -120,7 +120,7 @@ func TestValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get keys: %v", err)
 	}
-	if slices.Equal(values, got) {
+	if !slices.Equal(values, got) {
 		t.Errorf("got %v, expected %v", got, values)
 	}
 }

--- a/storage/map_test.go
+++ b/storage/map_test.go
@@ -1,0 +1,126 @@
+package storage
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestMapSetAndGet(t *testing.T) {
+	var db DB
+	mk, k, v := "mk", "k", "v"
+	if err := db.MapString(mk).Set(k, v); err != nil {
+		t.Fatalf("could not set value to key: %v", err)
+	}
+
+	got, err := db.MapString(mk).Get(k)
+	if err != nil {
+		t.Fatalf("could not get value from key: %v", err)
+	}
+	if got != v {
+		t.Errorf("got %v, expected %v", got, v)
+	}
+}
+
+func TestMapRemove(t *testing.T) {
+	var db DB
+	mk, k, v := "mk", "k", "v"
+	if err := db.MapString(mk).Set(k, v); err != nil {
+		t.Fatalf("could not set value to key: %v", err)
+	}
+
+	got, err := db.MapString(mk).Remove(k)
+	if err != nil {
+		t.Fatalf("could not remove value from key: %v", err)
+	}
+	if got != v {
+		t.Errorf("got %v, expected %v", got, v)
+	}
+	if _, err := db.MapString(mk).Get(k); err == nil {
+		t.Errorf("expected error: %v", ErrNotFound)
+	}
+}
+
+func TestContains(t *testing.T) {
+	var db DB
+	mk, k, v := "mk", "k", "v"
+	if err := db.MapString(mk).Set(k, v); err != nil {
+		t.Fatalf("could not set value to key: %v", err)
+	}
+
+	got, err := db.MapString(mk).Contains(k)
+	if err != nil {
+		t.Fatalf("could not check key: %v", err)
+	}
+	if got != true {
+		t.Errorf("expected to contain key")
+	}
+}
+
+func TestMapLen(t *testing.T) {
+	var db DB
+	mk := "mk"
+	m := map[string]string{"k1": "v1", "k2": "v2"}
+	for k, v := range m {
+		if err := db.MapString(mk).Set(k, v); err != nil {
+			t.Fatalf("could not set value to key: %v", err)
+		}
+	}
+	l, err := db.MapString(mk).Len()
+	if err != nil {
+		t.Fatalf("could not get map length: %v", err)
+	}
+	expected := len(m)
+	if l != expected {
+		t.Errorf("got length %d, expected %d", l, expected)
+	}
+}
+
+func TestKeys(t *testing.T) {
+	var db DB
+	mk := "mk"
+	m := map[string]string{"k1": "v1", "k2": "v2"}
+	keys := make([]string, len(m))
+	var i int
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	for k, v := range m {
+		if err := db.MapString(mk).Set(k, v); err != nil {
+			t.Fatalf("could not set value to key: %v", err)
+		}
+	}
+
+	got, err := db.MapString(mk).Keys()
+	if err != nil {
+		t.Fatalf("could not get keys: %v", err)
+	}
+	if slices.Equal(keys, got) {
+		t.Errorf("got %v, expected %v", got, keys)
+	}
+}
+
+func TestValues(t *testing.T) {
+	var db DB
+	mk := "mk"
+	m := map[string]string{"k1": "v1", "k2": "v2"}
+	values := make([]string, len(m))
+	var i int
+	for _, v := range m {
+		values[i] = v
+		i++
+	}
+	for k, v := range m {
+		if err := db.MapString(mk).Set(k, v); err != nil {
+			t.Fatalf("could not set value to key: %v", err)
+		}
+	}
+
+	got, err := db.MapString(mk).Values()
+	if err != nil {
+		t.Fatalf("could not get keys: %v", err)
+	}
+	if slices.Equal(values, got) {
+		t.Errorf("got %v, expected %v", got, values)
+	}
+}

--- a/storage/primitives.go
+++ b/storage/primitives.go
@@ -1,0 +1,96 @@
+package storage
+
+type Primitive interface {
+	string | int64 | float64 | bool | []byte
+}
+
+type PrimitiveQuery[T Primitive] struct {
+	DB  *DB
+	key string
+}
+
+func (pq *PrimitiveQuery[T]) Get() (T, error) {
+	var nothing T
+	value, ok := pq.DB.syncMap.Load(pq.key)
+	if !ok {
+		return nothing, ErrNotFound
+	}
+
+	primitive, ok := value.(T)
+	if !ok {
+		return nothing, ErrWrongType
+	}
+	return primitive, nil
+}
+
+func (pq *PrimitiveQuery[T]) Set(value T) {
+	pq.DB.syncMap.Store(pq.key, value)
+}
+
+func (pq *PrimitiveQuery[T]) Remove() (T, error) {
+	var nothing T
+	value, ok := pq.DB.syncMap.LoadAndDelete(pq.key)
+	primitive, ok := value.(T)
+	if !ok {
+		pq.DB.syncMap.Store(pq.key, value)
+		return nothing, ErrWrongType
+	}
+	return primitive, nil
+}
+
+func (pq *PrimitiveQuery[T]) Len() (int, error) {
+	value, ok := pq.DB.syncMap.Load(pq.key)
+	if !ok {
+		return 0, ErrNotFound
+	}
+
+	switch typed := value.(type) {
+	case string:
+		return len(typed), nil
+	case []byte:
+		return len(typed), nil
+	default:
+		return 0, ErrWrongType
+	}
+}
+
+func (pq *PrimitiveQuery[T]) Append(postfix string) error {
+	value, ok := pq.DB.syncMap.Load(pq.key)
+	if !ok {
+		return ErrNotFound
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return ErrWrongType
+	}
+	pq.DB.syncMap.Store(pq.key, str+postfix)
+	return nil
+}
+func (pq *PrimitiveQuery[T]) Increment() error {
+	value, ok := pq.DB.syncMap.Load(pq.key)
+	if !ok {
+		return ErrNotFound
+	}
+
+	num, ok := value.(int64)
+	if !ok {
+		return ErrWrongType
+	}
+	pq.DB.syncMap.Store(pq.key, num+1)
+	return nil
+}
+
+func (pq *PrimitiveQuery[T]) Decrement() error {
+	value, ok := pq.DB.syncMap.Load(pq.key)
+	if !ok {
+		return ErrNotFound
+	}
+
+	num, ok := value.(int64)
+	if !ok {
+		return ErrWrongType
+	}
+	pq.DB.syncMap.Store(pq.key, num-1)
+	return nil
+}

--- a/storage/primitives_test.go
+++ b/storage/primitives_test.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestSetAndGet(t *testing.T) {
+	db := DB{}
+	k, v := "k", "v"
+	db.String(k).Set(v)
+	got, err := db.String(k).Get()
+	if err != nil {
+		t.Fatalf("could not get value: %v", err)
+	}
+	if got != v {
+		t.Errorf("got %v, expected %v", got, v)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	db := DB{}
+	k, v := "k", "v"
+	db.String(k).Set(v)
+	got, err := db.String(k).Remove()
+	if err != nil {
+		t.Fatalf("could not delete value: %v", err)
+	}
+	if got != v {
+		t.Errorf("got %v, expected %v", got, v)
+	}
+	got, err = db.String(k).Get()
+	if got != "" {
+		t.Errorf("expected empty value, got %v", got)
+	}
+	if err != ErrNotFound {
+		t.Errorf("expected error: %v", ErrNotFound)
+	}
+}
+
+func TestLen(t *testing.T) {
+	db := DB{}
+	k, v := "k", "abcde"
+	db.String(k).Set(v)
+	l, err := db.String(k).Len()
+	if err != nil {
+		t.Fatalf("could not get length: %v", err)
+	}
+	expected := len(v)
+	if l != expected {
+		t.Errorf("got length %d, expected %d", l, expected)
+	}
+}
+
+func TestAppend(t *testing.T) {
+	db := DB{}
+	k, v := "k", "abcd"
+	postfix := "efgh"
+	db.String(k).Set(v)
+	if err := db.String(k).Append(postfix); err != nil {
+		t.Fatalf("could not append string: %v", err)
+	}
+	got, err := db.String(k).Get()
+	if err != nil {
+		t.Fatalf("could not get value: %v", err)
+	}
+	expected := v + postfix
+	if got != expected {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestIncrement(t *testing.T) {
+	db := DB{}
+	k, v := "k", int64(1)
+	db.Int(k).Set(v)
+	if err := db.Int(k).Increment(); err != nil {
+		t.Fatalf("could not increment number: %v", err)
+	}
+	got, err := db.Int(k).Get()
+	if err != nil {
+		t.Fatalf("could not get value: %v", err)
+	}
+	expected := v + 1
+	if got != expected {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestDecrement(t *testing.T) {
+	db := DB{}
+	k, v := "k", int64(1)
+	db.Int(k).Set(v)
+	if err := db.Int(k).Decrement(); err != nil {
+		t.Fatalf("could not increment number: %v", err)
+	}
+	got, err := db.Int(k).Get()
+	if err != nil {
+		t.Fatalf("could not get value: %v", err)
+	}
+	expected := v - 1
+	if got != expected {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}


### PR DESCRIPTION
This pull request introduces a concurrency-safe key-value in-memory storage with support for the following primitive types:
- string
-  int64
-  float64
-  []byte

In addition to primitive types, the storage also supports composite types  that hold values of supported primitive types:
- arrays
- maps

All public methods are covered by unit tests.